### PR TITLE
fix: made mmr nullable on the search results as sometimes if the user…

### DIFF
--- a/src/R6Tab.NET/Models/SearchResults.cs
+++ b/src/R6Tab.NET/Models/SearchResults.cs
@@ -75,7 +75,7 @@ namespace R6Tab.NET.Models
         public decimal Kd { get; set; }
 
         [JsonProperty("mmr")]
-        public short Mmr { get; set; }
+        public short? Mmr { get; set; }
 
         [JsonProperty("rank")]
         public byte Rank { get; set; }


### PR DESCRIPTION
… profile had not been loaded on r6tab before the mmr would be null